### PR TITLE
#6e2f75 환경 - ReactDOM.render > CreateRoot로 변경

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,15 +1,17 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 
 import { BrowserRouter } from 'react-router-dom';
 
-ReactDOM.render(
+const root = ReactDOM.createRoot(
+  document.getElementById('root') as HTMLElement,
+);
+root.render(
   <React.StrictMode>
     <BrowserRouter>
       <App />
     </BrowserRouter>
   </React.StrictMode>,
-  document.getElementById('root'),
 );


### PR DESCRIPTION
Warning: ReactDOM.render is no longer supported in React 18. Use createRoot instead. Until you switch to the new API, your app will behave as if it's running React 17. 

콘솔에 뜨는 상단 에러 React 18 에서 더이상 ReactDOM.render가 지원되지 않아 ReactDOM.CreateRoot로 변경하였으니 참고바랍니다 :)